### PR TITLE
Handle load balancer ip string

### DIFF
--- a/throttle/zones/remoteip.py
+++ b/throttle/zones/remoteip.py
@@ -6,4 +6,9 @@ class RemoteIP:
         """
         Return our best crack at the remote IP address
         """
-        return request.META.get('HTTP_X_FORWARDED_FOR', "") or request.META.get('REMOTE_ADDR')
+        # Handle Load Balancer case
+        # Load balancer returns usually in format of 'xx.xx.xx.xx, yy.yy.yy.yy, zz.zz.zz.zz'
+        # where xx.xx.xx.xx is the actual ip while others vary on the request
+        ip_string = request.META.get('HTTP_X_FORWARDED_FOR', "")
+        ip_string = ip_string.split(',')[0]
+        return ip_string or request.META.get('REMOTE_ADDR')


### PR DESCRIPTION
I was working with a load balancer, I couldn't get the correct key due to varying ip string returned in HTTP_X_FORWARDED_FOR meta.